### PR TITLE
Replace static region 'us-east-1' in method listBuckets() with variable's value

### DIFF
--- a/lib/src/minio.dart
+++ b/lib/src/minio.dart
@@ -439,7 +439,7 @@ class Minio {
   Future<List<Bucket>> listBuckets() async {
     final resp = await _client.request(
       method: 'GET',
-      region: 'us-east-1',
+      region: region ?? 'us-east-1',
     );
     final bucketsNode =
         xml.XmlDocument.parse(resp.body).findAllElements('Buckets').first;


### PR DESCRIPTION
I'm using your library in combination with an S3 bucket located at the region `eu-central-1` and ran into an exception when using the method `listBuckets()`.

The exception is caused because the method `listBuckets()` always sets the region to `us-east-1`. As a result, AWS returns an HTTP response with error code 400 and this HTTP response body:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Error>
    <Code>AuthorizationHeaderMalformed</Code>
    <Message>The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-central-1'</Message>
    <Region>eu-central-1</Region>
    <RequestId>BB0B1B4E********</RequestId>
    <HostId>Gz+lnRXxVhX*****************************************************************</HostId>
</Error>
```
This in turn leads to the following exception because the response doesn't contain any buckets to iterate over:

```
Unhandled exception:
Bad state: No element
#0      Iterable.first (dart:core/iterable.dart:524:7)
#1      Minio.listBuckets
package:minio/src/minio.dart:445
<asynchronous suspension>
#2      main
example/minio_example.dart:18
#3      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:301:19)
#4      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:168:12)
```

I think that I don't need to explain the bug fix. If no region is set, the method defaults to `us-east-1`. This way, my change shouldn't break anyone's code.

I tested it with my S3 bucket on AWS and also with the MinIO instance deployed at `play.minio.io`. It worked perfectly fine in both cases! Using MinIO, I can even omit the region and still get the correct response (MinIO seems to be very forgiving).

Thank you for your awesome library :tada: 