### PR TITLE
fix bucketExists is true when bucket doesn't exist

### DIFF
--- a/lib/minio.dart
+++ b/lib/minio.dart
@@ -1,8 +1,6 @@
-/// Support for doing something awesome.
-///
-/// More dartdocs go here.
 library minio;
 
 export 'src/minio.dart';
+export 'src/minio_errors.dart';
 
 // TODO: Export any libraries intended for clients of this package.

--- a/lib/src/minio.dart
+++ b/lib/src/minio.dart
@@ -68,15 +68,15 @@ class Minio {
 
   /// Checks if a bucket exists.
   ///
-  /// Returns `true` if the [bucket] exists or you don't have permission to access
-  /// it (which implies that it exists). Returns `false` only if the [bucket] does
-  /// not exist.
+  /// Returns `true` only if the [bucket] exists and you have the permission
+  /// to access it. Returns `false` if the [bucket] does not exist or you
+  /// don't have the permission to access it.
   Future<bool> bucketExists(String bucket) async {
     MinioInvalidBucketNameError.check(bucket);
     try {
       final response = await _client.request(method: 'HEAD', bucket: bucket);
       validate(response);
-      return (response.statusCode == 200 || response.statusCode == 403);
+      return response.statusCode == 200;
     } on MinioS3Error catch (e) {
       final code = e.error.code;
       if (code == 'NoSuchBucket' || code == 'NotFound' || code == 'Not Found') {

--- a/lib/src/minio.dart
+++ b/lib/src/minio.dart
@@ -67,13 +67,28 @@ class Minio {
   final _regionMap = <String, String>{};
 
   /// Checks if a bucket exists.
+  ///
+  /// Returns `true` if the [bucket] exists or you don't have permission to access
+  /// it (which implies that it exists). Returns `false` only if the [bucket] does
+  /// not exist.
   Future<bool> bucketExists(String bucket) async {
     MinioInvalidBucketNameError.check(bucket);
     try {
-      await _client.request(method: 'HEAD', bucket: bucket);
+      final response = await _client.request(method: 'HEAD', bucket: bucket);
+      return (response.statusCode == 200 || response.statusCode == 403);
     } on MinioS3Error catch (e) {
       final code = e.error.code;
       if (code == 'NoSuchBucket' || code == 'NotFound') return false;
+      rethrow;
+    } on StateError catch (e) {
+      // Insight from testing: in most cases, AWS S3 returns the HTTP status code
+      // 404 when a bucket does not exist. Whereas in other cases, when the bucket
+      // does not exist, S3 returns the HTTP status code 301 Redirect instead of
+      // status code 404 as officially documented. Then, this redirect response
+      // lacks the HTTP header `location` which causes this exception in Dart's
+      // HTTP library (`http_impl.dart`).
+      if (e.message == 'Response has no Location header for redirect')
+        return false;
       rethrow;
     }
     return true;

--- a/lib/src/minio_helpers.dart
+++ b/lib/src/minio_helpers.dart
@@ -217,9 +217,17 @@ Future<void> validateStreamed(
 
 void validate(Response response, {int expect}) {
   if (response.statusCode >= 400) {
-    final body = xml.XmlDocument.parse(response.body);
-    final error = Error.fromXml(body.rootElement);
-    throw MinioS3Error(error.message, error, response);
+    var error;
+
+    // Parse HTTP response body as XML only when not empty
+    if (response.body == null || response.body.isEmpty) {
+      error = Error(response.reasonPhrase, null, response.reasonPhrase, null);
+    } else {
+      final body = xml.XmlDocument.parse(response.body);
+      error = Error.fromXml(body.rootElement);
+    }
+
+    throw MinioS3Error(error?.message, error, response);
   }
 
   if (expect != null && response.statusCode != expect) {

--- a/test/minio_dart_test.dart
+++ b/test/minio_dart_test.dart
@@ -39,6 +39,58 @@ void main() {
       );
     });
   });
+
+  group('bucketExists', () {
+    final bucketName = DateTime.now().millisecondsSinceEpoch.toString();
+
+    setUpAll(() async {
+      final minio = _getClient();
+      await minio.makeBucket(bucketName);
+    });
+
+    tearDownAll(() async {
+      final minio = _getClient();
+      await minio.removeBucket(bucketName);
+    });
+
+    test('bucketExists() returns true for an existing bucket', () async {
+      final minio = _getClient();
+      expect(await minio.bucketExists(bucketName), equals(true));
+    });
+
+    test('bucketExists() returns false for a non-existent bucket', () async {
+      final minio = _getClient();
+      expect(await minio.bucketExists('non-existing-bucket-name'), equals(false));
+    });
+
+    test('bucketExists() fails due to wrong access key', () async {
+      final minio = _getClient(accessKey: 'incorrect-access-key');
+      expect(
+        () async => await minio.bucketExists(bucketName),
+        throwsA(
+          isA<MinioError>().having(
+            (e) => e.message,
+            'message',
+            'Forbidden',
+          ),
+        ),
+      );
+    });
+
+    test('bucketExists() fails due to wrong secret key', () async {
+      final minio = _getClient(secretKey: 'incorrect-secret-key');
+      expect(
+        () async => await minio.bucketExists(bucketName),
+        throwsA(
+          isA<MinioError>().having(
+            (e) => e.message,
+            'message',
+            'Forbidden',
+          ),
+        ),
+      );
+    });
+  });
 }
 
 /// Initializes an instance of [Minio] with per default valid configuration.

--- a/test/minio_dart_test.dart
+++ b/test/minio_dart_test.dart
@@ -1,14 +1,67 @@
+import 'package:minio/minio.dart';
+import 'package:test/test.dart';
 
 void main() {
-  // group('A group of tests', () {
-  //   Awesome awesome;
+  group('listBuckets', () {
+    test('listBuckets() succeeds', () async {
+      final minio = _getClient();
 
-  //   setUp(() {
-  //     awesome = Awesome();
-  //   });
+      expect(() async => await minio.listBuckets(), returnsNormally);
+    });
 
-  //   test('First Test', () {
-  //     expect(awesome.isAwesome, isTrue);
-  //   });
-  // });
+    test('listBuckets() fails due to wrong access key', () async {
+      final minio = _getClient(accessKey: 'incorrect-access-key');
+
+      expect(
+        () async => await minio.listBuckets(),
+        throwsA(
+          isA<MinioError>().having(
+            (e) => e.message,
+            'message',
+            'The Access Key Id you provided does not exist in our records.',
+          ),
+        ),
+      );
+    });
+
+    test('listBuckets() fails due to wrong secret key', () async {
+      final minio = _getClient(secretKey: 'incorrect-secret-key');
+
+      expect(
+        () async => await minio.listBuckets(),
+        throwsA(
+          isA<MinioError>().having(
+            (e) => e.message,
+            'message',
+            'The request signature we calculated does not match the signature you provided. Check your key and signing method.',
+          ),
+        ),
+      );
+    });
+  });
 }
+
+/// Initializes an instance of [Minio] with per default valid configuration.
+///
+/// Don't worry, these credentials for MinIO are publicly available and
+/// connect only to the MinIO demo server at `play.minio.io`.
+Minio _getClient({
+  String endpoint = 'play.minio.io',
+  int port = 443,
+  bool useSSL = true,
+  String accessKey = 'Q3AM3UQ867SPQQA43P2F',
+  String secretKey = 'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
+  String sessionToken = '',
+  String region = 'us-east-1',
+  bool enableTrace = false,
+}) =>
+    Minio(
+      endPoint: endpoint,
+      port: port,
+      useSSL: useSSL,
+      accessKey: accessKey,
+      secretKey: secretKey,
+      sessionToken: sessionToken,
+      region: region,
+      enableTrace: enableTrace,
+    );


### PR DESCRIPTION
This pull request addresses issue #5 .

The problem was, that the previous implementation didn't check the HTTP response code from S3. Instead, the code was only surrounded by a try-catch block which could not catch the case when the bucket didn't exist.

[The official S3 API reference states](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html):

> HeadBucket
>
> This operation is useful to determine if a bucket exists and you have permission to access it. The operation **returns a 200 OK** if the bucket exists and you have permission to access it. Otherwise, the operation might return responses such as **404 Not Found and 403 Forbidden**. 

I tested it with AWS S3 and a local MinIO instance.

**Important:**
My proposed implementation returns `true`, if S3 returns HTTP status code 200 (OK) or 403 (Forbidden). I'm not sure about the latter. The S3 spec states that 403 is returned when the user has no sufficient permissions. Although, incorrect credentials (access key + secret key) result in HTTP status code 403, too. What do you think about this @xtyxtyx? Maybe, I should change this so that the function only returns `true` in case of a HTTP 200 response?
