### PR TITLE
metaData fix in putObject and fPutObject (content-type: 'image/jpeg' is ignored )

### DIFF
--- a/lib/io.dart
+++ b/lib/io.dart
@@ -28,7 +28,7 @@ extension MinioX on Minio {
       );
     }
 
-    return putObject(bucket, object, file.openRead(), stat.size);
+    return putObject(bucket, object, file.openRead(), stat.size, metaData);
   }
 
   /// Downloads and saves the object as a file in the local filesystem.

--- a/lib/src/minio.dart
+++ b/lib/src/minio.dart
@@ -841,9 +841,9 @@ class Minio {
     String bucket,
     String object,
     Stream<List<int>> data,
-    int size, {
+    int size,
     Map<String, String> metadata,
-  }) async {
+  ) async {
     MinioInvalidBucketNameError.check(bucket);
     MinioInvalidObjectNameError.check(object);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: minio
 description: Unofficial MinIO Dart Client SDK that provides simple APIs to access any Amazon S3 compatible object storage server.
-version: 1.1.0-pre
-homepage: https://github.com/xtyxtyx/minio-dart
+version: 1.1.0-pre-hlck
+homepage: https://github.com/hlacik/minio-dart
 issue_tracker: https://github.com/xtyxtyx/minio-dart/issues
 
 environment:


### PR DESCRIPTION
Hello,
when uploading image via fPutObject metadata are ignored

implementation of fPutObject does

metaData = insertContentType(metaData, filePath);

which correctly returns 'image/jpeg' ,

by using lookupMimeType(path)

however this map is not provided to putObject which is called at the end as a part of return

another problem is that putObject has Map<String, String> metadata wrapped in {}

as the result image uploaded has wrong metadata 

`david@jtsnc:~$ mc stat minio/input/test.jpg
Name      : test.jpg
Date      : 2020-12-11 11:39:10 UTC 
Size      : 3.2 MiB 
ETag      : 55e92ea2232c5354993c4e50473351f8 
Type      : file 
Metadata  :
  Content-Type: application/octet-stream `

my fix, solves issue
thanks for a great project!
