### PR TITLE
fix HTTP header for user-defined object metadata

### DIFF
--- a/lib/src/minio_helpers.dart
+++ b/lib/src/minio_helpers.dart
@@ -130,7 +130,7 @@ Map<String, String> prependXAMZMeta(Map<String, String> metadata) {
     if (!isAmzHeader(key) &&
         !isSupportedHeader(key) &&
         !isStorageclassHeader(key)) {
-      newMetadata['X-Amz-Meta-' + key] = newMetadata[key];
+      newMetadata['x-amz-meta-' + key] = newMetadata[key];
       newMetadata.remove(key);
     }
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -82,9 +82,7 @@ class BlockStream extends StreamTransformerBase<List<int>, List<int>> {
       }
     }
 
-    if (buffer.length != 0) {
-      yield buffer.toBytes();
-    }
+    yield buffer.toBytes();
   }
 }
 

--- a/test/minio_dart_test.dart
+++ b/test/minio_dart_test.dart
@@ -155,6 +155,18 @@ void main() {
       expect(stat.metaData[userDefinedMetadataKey],
           equals(userDefinedMetadataValue));
     });
+
+    test('fPutObject() with empty file', () async {
+      final objectName = 'empty.txt';
+      final emptyFile = await File('${tempDir.path}/$objectName').create();
+      await emptyFile.writeAsString('');
+
+      final minio = _getClient();
+      await minio.fPutObject(bucketName, objectName, emptyFile.path);
+
+      final stat = await minio.statObject(bucketName, objectName);
+      expect(stat.size, equals(0));
+    });
   });
 }
 


### PR DESCRIPTION
There was a typo in `prependXAMZMeta()`. According to the S3 documentation, when adding user-defined object metadata, the metadata key must start with the **all-lowercase** prefix `x-amz-meta-`. I also added two unit tests for testing the metadata feature.

See S3 doc: [https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#UserMetadata](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#UserMetadata)