### PR TITLE
Pass the JWT sessionToken to MinIO as header

### DIFF
--- a/lib/src/minio_client.dart
+++ b/lib/src/minio_client.dart
@@ -154,6 +154,9 @@ class MinioClient {
 
     final authorization = signV4(minio, request, date, region);
     request.headers['authorization'] = authorization;
+    if(minio.sessionToken != null) {
+      request.headers['X-Amz-Security-Token'] = minio.sessionToken ?? '';
+    }
 
     logRequest(request);
     final response = await request.send();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   http: ^0.13.1
   crypto: ^3.0.0
   convert: ^3.0.0
-  xml: ^5.0.2
+  xml: ^6.0.2
   buffer: ^1.1.0
   intl: ^0.17.0
   mime: ^1.0.0


### PR DESCRIPTION
The header `X-Amz-Security-Token` was missing, when setting the `Minio(sessionToken: sessionToken)`, which was obtained using a JWT. This causes MinIo to reject the requests. This pull request checks if if the user set it and adds it to the headers. Also, I bumped up the xml version, as the new version works fine.