### PR TITLE
Updated intl Version support for Flutter Version 3.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,16 +5,16 @@ homepage: https://github.com/xtyxtyx/minio-dart
 issue_tracker: https://github.com/xtyxtyx/minio-dart/issues
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.0.0 <3.10.0"
 
 dependencies:
   meta: ^1.3.0
   http: ^0.13.1
   crypto: ^3.0.0
   convert: ^3.0.0
-  xml: ^5.0.2
+  xml: ^6.3.0
   buffer: ^1.1.0
-  intl: ^0.17.0
+  intl: ^0.18.1
   mime: ^1.0.0
   path: ^1.8.0
 


### PR DESCRIPTION
This update has Fixed Intl Version of minio-dart after upgrading to Flutter Version 3.10.0. 
Fixed #77 and #78 