### PR TITLE
Fix non en-US date time parse

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -122,13 +122,13 @@ String trimDoubleQuote(String str) {
 }
 
 DateTime parseRfc7231Time(String time) {
-  final format = DateFormat('EEE, dd MMM yyyy HH:mm:ss');
+  final format = DateFormat('EEE, dd MMM yyyy HH:mm:ss', 'en-US');
   final isUtc = time.endsWith('GMT');
   return format.parse(time, isUtc);
 }
 
 String toRfc7231Time(DateTime time) {
-  final format = DateFormat('EEE, dd MMM yyyy HH:mm:ss');
+  final format = DateFormat('EEE, dd MMM yyyy HH:mm:ss', 'en-US');
   final result = format.format(time);
   return time.isUtc ? '$result GMT' : result;
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:minio/src/utils.dart';
 import 'package:test/test.dart';
 
@@ -25,6 +27,20 @@ void testRfc7231Time() {
       expect(parseRfc7231Time(timeStringUtc), equals(timeUtc));
       expect(parseRfc7231Time(timeStringUtc).isUtc, isTrue);
     });
+
+    test(
+      'works for non en-US locale', () async {
+        initializeDateFormatting('pt_BR');
+        Intl.withLocale(
+          'pt_BR',
+          ()
+          {
+            expect(parseRfc7231Time(timeStringUtc), equals(timeUtc));
+            expect(parseRfc7231Time(timeStringUtc).isUtc, isTrue);
+          }
+        );
+      }
+    );
   });
 
   group('toRfc7231Time', () {
@@ -35,6 +51,19 @@ void testRfc7231Time() {
     test('works for GMT time', () {
       expect(toRfc7231Time(timeUtc), equals(timeStringUtc));
     });
+
+    test(
+      'works for non en-US locale', () async {
+        initializeDateFormatting('pt_BR');
+        Intl.withLocale(
+          'pt_BR',
+          ()
+          {
+            expect(toRfc7231Time(timeUtc), equals(timeStringUtc));
+          }
+        );
+      }
+    );
   });
 }
 


### PR DESCRIPTION
When the application is running in a system set up with a language different than english it fails to parse MinIO datetime headers.

Below is the error that I've experienced
```
FormatException: Trying to read EEE from Sat, 02 Nov 2024 22:46:54 GMT at 0
       at _DateFormatField.throwFormatException(date_format_field.dart:87)
       at _DateFormatPatternField.parseField(date_format_field.dart:350)
       at _DateFormatPatternField.parse(date_format_field.dart:261)
       at DateFormat._parse(date_format.dart:448)
       at DateFormat.parse(date_format.dart:315)
       at .parseRfc7231Time(utils.dart:127)
       at Minio.statObject(minio.dart:1138)
```

I took the liberty to fix this by hardcoding the locale to en-US as it seems to be the correct value for the header.