### PR TITLE
fix maxKeys error while using listObject query

### DIFF
--- a/lib/src/minio.dart
+++ b/lib/src/minio.dart
@@ -564,7 +564,7 @@ class Minio {
 
     if (maxKeys != null) {
       maxKeys = maxKeys >= 1000 ? 1000 : maxKeys;
-      queries['maxKeys'] = maxKeys.toString();
+      queries['max-keys'] = maxKeys.toString();
     }
 
     final resp = await _client.request(
@@ -674,7 +674,7 @@ class Minio {
 
     if (maxKeys != null) {
       maxKeys = maxKeys >= 1000 ? 1000 : maxKeys;
-      queries['maxKeys'] = maxKeys.toString();
+      queries['max-keys'] = maxKeys.toString();
     }
 
     final resp = await _client.request(


### PR DESCRIPTION
I was getting the below error while using it with cloudflare R2 storage to list objects.
`MinioError: ListObjectsV2 search parameter maxKeys not implemented`